### PR TITLE
Add Issue Templates Without : in Labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -1,0 +1,24 @@
+---
+name: Bug
+about: Issue to report a bug in the software
+title: "Bug - "
+labels: Bug, Priority Urgent, Priority High, Priority Medium, Priority Low
+---
+
+<!---
+Instructions:
+- Remove the non-required priority labels to indicate the correct priority
+- Fill in the below details
+- Delete comments for completeness
+
+NOTE: Bugs should not be sized or placed within a Sprint
+-->
+
+### Details of Bug
+<!-- Detail the nature of the bug -->
+
+### Recreation Steps
+1. Steps to recreate the issue here
+
+### Comments
+<!-- Any other comments can go here -->

--- a/.github/ISSUE_TEMPLATE/epic-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-template.md
@@ -1,0 +1,20 @@
+---
+name: Epic
+about: Issue to hold an epic
+title: "Epic - "
+labels: Epic, Sprint 0
+---
+
+<!---
+Instructions:
+- Fill out the description
+- Add a list of all of the relevant issues to the epic
+-->
+
+### Epic Details
+<!-- Describe the epic at a high level -->
+
+### Stories
+1. #x
+2. #y
+3. #z

--- a/.github/ISSUE_TEMPLATE/feature-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-template.md
@@ -1,0 +1,29 @@
+---
+name: Feature
+about: Issue to indicate a new feature to be added to the project
+title: "Feature - "
+labels: Feature, Priority Urgent, Priority High, Priority Medium, Priority Low, Size Extra Large, Size Large, Size Medium, Size Small, Sprint 0
+---
+
+<!---
+Instructions:
+- Remove the non-required priority labels to indicate the correct priority
+- Remove the non-required size labels to indicate the correct size
+- Fill in the below details
+- Delete comments for completeness
+-->
+
+### User Story
+<!-- Detail the user story for this feature e.g. "A user should be able to create an issue with a defined template to ensure consistent issue formatting -->
+
+### Requirements
+- [ ] List requirements here
+
+### Design
+<!-- Detail the design of how the feature will be implemented here -->
+
+### Infrastructure Requirements
+<!-- Are there any infrastructure requirements for this feature that are pre-requisite? -->
+
+### Comments
+<!-- Any other comments can go here -->

--- a/.github/ISSUE_TEMPLATE/infrastructure-template.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure-template.md
@@ -1,0 +1,26 @@
+---
+name: Infrastructure
+about: Issue to indicate a change to infrastructure is required
+title: "Infrastructure - "
+labels: Infrastructure, Priority Urgent, Priority High, Priority Medium, Priority Low, Size Extra Large, Size Large, Size Medium, Size Small, Sprint 0
+---
+
+<!---
+Instructions:
+- Remove the non-required priority labels to indicate the correct priority
+- Remove the non-required size labels to indicate the correct size
+- Fill in the below details
+- Delete comments for completeness
+-->
+
+### Details of Change
+<!-- Detail the nature of the changes -->
+
+### Requirements
+- [ ] List requirements here
+
+### Design
+<!-- Detail the design of how the feature will be implemented here -->
+
+### Comments
+<!-- Any other comments can go here -->


### PR DESCRIPTION
RE #1
See #6 and #5 

An issue occured with the template creation due to the `:` character in the labels - I felt that on review the labels would be better without `:`s anyway so I have removed the colons and updated the templates.