### PR TITLE
Bug Busting - Fix Various Bugs

### DIFF
--- a/frontend/__tests__/Editor.test.jsx
+++ b/frontend/__tests__/Editor.test.jsx
@@ -192,6 +192,7 @@ describe("Markdown Editor", () => {
     render(<EditorPage />);
     const clearMarkdown = screen.getByText("Clear Markdown");
     const textarea = screen.getByTestId("markdown-editor");
+    const preview = screen.getByTestId("markdown-preview");
 
     fireEvent.change(textarea, { target: { value: "Hello" } });
     expect(textarea.value).toBe("Hello");
@@ -201,6 +202,7 @@ describe("Markdown Editor", () => {
 
     fireEvent.click(clearMarkdown);
     expect(textarea.value).toBe("");
+    expect(preview.innerHTML).toBe("");
   });
 
   test("that the Clear Markdown button does not clear the text in the textarea if not confirmed", () => {

--- a/frontend/__tests__/Editor.test.jsx
+++ b/frontend/__tests__/Editor.test.jsx
@@ -101,6 +101,8 @@ describe("Markdown Editor", () => {
 
     localStorage.clear();
 
+    localStorage.setItem("markdown", "");
+
     render(<EditorPage />);
     const textarea = screen.getByTestId("markdown-editor");
 

--- a/frontend/__tests__/Editor.test.jsx
+++ b/frontend/__tests__/Editor.test.jsx
@@ -128,6 +128,26 @@ describe("Markdown Editor", () => {
     expect(localStorage.getItem("markdown")).toBe("# Hello");
   });
 
+  test("that the default Markdown is not used when markdown property is just empty", async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        html: "",
+      },
+    });
+
+    localStorage.clear();
+
+    localStorage.setItem("markdown", "");
+
+    render(<EditorPage />);
+    const textarea = screen.getByTestId("markdown-editor");
+
+    await waitFor(() => {
+      expect(axios.post).not.toHaveBeenCalled();
+      expect(textarea.value).toBe("");
+    });
+  });
+
   test("that unsafe HTML is not rendered in the preview", async () => {
     const maliciousHTML = "<img src=\"x\" onerror=\"alert(\"Hacked!\")\" />";
     axios.post.mockResolvedValueOnce({

--- a/frontend/src/app/editor/editor.css
+++ b/frontend/src/app/editor/editor.css
@@ -73,7 +73,7 @@
     height: 100%;
     padding: 0.6rem;
     background: var(--interactable-background);
-    ;
+    text-align: left;
     overflow-y: auto;
     word-wrap: break-word;
     overflow-wrap: break-word;

--- a/frontend/src/app/editor/page.js
+++ b/frontend/src/app/editor/page.js
@@ -76,9 +76,10 @@ export default function EditorPage() {
   };
 
   useEffect(() => {
-    console.log(localStorage.getItem("markdown"));
-    if (localStorage.getItem("markdown")) {
+    if (localStorage.hasOwnProperty("markdown")) {
       handleEditorChange(localStorage.getItem("markdown"));
+    } else {
+      handleEditorChange(sampleMarkdown);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -224,7 +225,7 @@ export default function EditorPage() {
     const handleGlobalKeyDown = (event) => {
       // Prevent default action for Ctrl/Cmd + S and Ctrl/Cmd + O
       if (event.ctrlKey || event.metaKey) {
-        if (event.key === "s") {
+        if (event.key === "s") {``
           event.preventDefault();
           saveMarkdown();
         } else if (event.key === "o") {
@@ -327,3 +328,38 @@ export default function EditorPage() {
     </div>
   );
 }
+
+const sampleMarkdown =
+`# Welcome to GoodMark Editor!
+
+This is a Markdown editor where you can edit and preview your content.
+
+## Features
+
+- **Real-time preview**
+- **Customizable fonts**
+- **Dark/Light mode toggle**
+
+### Markdown allows you to:
+
+1. **Create headings**: # for large headers, ## for medium headers, and ### for smaller ones.
+2. **Style text**: You can make text **bold**, *italic*, or even monospace for code (\`\`\`).
+3. **Write Code blocks**: Using \`\`\`, you can also specify a language on the first line for syntax highlighting. 
+
+    \`\`\`javascript
+    // Example of JavaScript code
+    function greet() {
+      console.log("Hello, World!");
+    }
+    \`\`\`
+
+4. **Add Links**: Such as [this one](https://google.com/) to Google
+
+5. **Add Images**:
+
+     ![Markdown Logo](https://cdn.commonmark.org/uploads/default/optimized/2X/3/366f3614de6996d79a131fdf9b41ed7d65cfe181_2_1024x630.png)
+
+---
+
+> GoodMark makes writing Markdown quick and easy
+`

--- a/frontend/src/app/editor/page.js
+++ b/frontend/src/app/editor/page.js
@@ -86,6 +86,7 @@ export default function EditorPage() {
 
   const handleRender = async (markdown) => {
     if (!markdown) {
+      setRenderedText();
       return;
     }
 
@@ -198,7 +199,7 @@ export default function EditorPage() {
 
   const clearMarkdown = () => {
     if (activeClear) {
-      setEditorText("");
+      handleEditorChange("");
 
       setActiveClear(false);
       return;

--- a/frontend/src/app/editor/page.js
+++ b/frontend/src/app/editor/page.js
@@ -54,18 +54,24 @@ export default function EditorPage() {
       setIsDarkMode(prefersDarkMode);
       localStorage.setItem("data-theme", prefersDarkMode ? "dark" : "light");
     }
+
+    setHasRunYet(true);
   }, []);
 
   useEffect(() => {
+    if (!hasRunYet) return;
+
     const root = document.documentElement;
     if (isDarkMode) {
       setCurrentIcon("darkMode.svg");
       root.setAttribute("data-theme", "dark");
+      localStorage.setItem("data-theme", "dark");
     } else {
       setCurrentIcon("lightMode.svg");
       root.setAttribute("data-theme", "light");
+      localStorage.setItem("data-theme", "light");
     }
-  }, [isDarkMode]);
+  }, [isDarkMode, hasRunYet]);
 
 
   const handleEditorChange = (newValue) => {

--- a/frontend/src/app/editor/page.js
+++ b/frontend/src/app/editor/page.js
@@ -235,6 +235,12 @@ export default function EditorPage() {
         }
       }
     }
+
+    window.addEventListener("keydown", handleGlobalKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleGlobalKeyDown);
+    };
   });
 
   useEffect(() => {

--- a/frontend/src/app/editor/page.js
+++ b/frontend/src/app/editor/page.js
@@ -364,7 +364,7 @@ This is a Markdown editor where you can edit and preview your content.
 
 5. **Add Images**:
 
-     ![Markdown Logo](https://cdn.commonmark.org/uploads/default/optimized/2X/3/366f3614de6996d79a131fdf9b41ed7d65cfe181_2_1024x630.png)
+    ![Markdown Logo](https://cdn.commonmark.org/uploads/default/optimized/2X/3/366f3614de6996d79a131fdf9b41ed7d65cfe181_2_1024x630.png)
 
 ---
 


### PR DESCRIPTION
Fixes #68 fixes #69 fixes #70 fixes #71 fixes #72

Fix various bugs 
- Default Markdown is used on refresh when Markdown is empty
- Clear Markdown does not clear preview
- Keyboard controls had regressed
- Markdown preview was centred when entering from Welcome page
- Dark Light mode saving had regressed